### PR TITLE
config: honor XDG_RUNTIME_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The dnsname plugin can be enabled in the cni network configuration file.
 
 ## DNSMasq configuration files
 The dnsmasq service and its configuration files are considered to be very fluid and are not meant to survive a system
-reboot.  Therefore, files are stored in `/run/containers/cni/dnsname`. The plugin knows to recreate the necessary
-files if it detects they are not present.
+reboot.  Therefore, files are stored in `/run/containers/cni/dnsname`, or under `$XDG_RUNTIME_DIR/containers/cni/dnsname` if
+`XDG_RUNTIME_DIR` is specified.  The plugin knows to recreate the necessary files if it detects they are not present.
 
 ##  DNSMasq default configuration
 Much like the implementation of DNSMasq for libvirt, this plugin will only set up dnsmasq to listen on the network

--- a/plugins/meta/dnsname/config.go
+++ b/plugins/meta/dnsname/config.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/containernetworking/cni/pkg/types"
 )
 
 const (
-	//	dnsNameConfPath is where we store the conf, pid, and hosts files
-	dnsNameConfPath = "/run/containers/cni/dnsname"
 	// confFileName is the name of the dns masq conf file
 	confFileName = "dnsmasq.conf"
 	// hostsFileName is the name of the addnhosts file
@@ -52,4 +52,13 @@ type dnsNameFile struct {
 	Domain           string
 	NetworkInterface string
 	PidFile          string
+}
+
+// dnsNameConfPath tells where we store the conf, pid, and hosts files
+func dnsNameConfPath() string {
+	xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntimeDir != "" {
+		return filepath.Join(xdgRuntimeDir, "containers/cni/dnsname")
+	}
+	return "/run/containers/cni/dnsname"
 }

--- a/plugins/meta/dnsname/main.go
+++ b/plugins/meta/dnsname/main.go
@@ -193,7 +193,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 		return errors.Errorf("dnsmasq instance not running")
 	}
 	// Above will make sure the pidfile exists
-	files, err := ioutil.ReadDir(dnsNameConfPath)
+	files, err := ioutil.ReadDir(dnsNameConfPath())
 	if err != nil {
 		return err
 	}

--- a/plugins/meta/dnsname/service.go
+++ b/plugins/meta/dnsname/service.go
@@ -96,5 +96,5 @@ func (d dnsNameFile) getProcess() (*os.Process, error) {
 func makePath(networkName, fileName string) string {
 	// the generic path for where conf, host, pid files are kept is:
 	// /run/containers/cni/dnsmasq/<network-name>/
-	return filepath.Join(dnsNameConfPath, networkName, fileName)
+	return filepath.Join(dnsNameConfPath(), networkName, fileName)
 }


### PR DESCRIPTION
enable to work from a rootless environment.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>