### PR TITLE
pass aliases to dns masq

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ The dnsname plugin can be enabled in the cni network configuration file.
       },
       {
         "type": "dnsname",
-        "domainName": "foobar.com"
+        "domainName": "foobar.com",
+        "capabilities": {
+            "aliases": true
+        }
       }
     ]
 }
@@ -42,6 +45,10 @@ reboot.  Therefore, files are stored in `/run/containers/cni/dnsname`, or under 
 Much like the implementation of DNSMasq for libvirt, this plugin will only set up dnsmasq to listen on the network
 interfaces associated with the CNI network.  The DNSMasq services are not configured or managed by systemd but rather
 only by the plugin itself.
+
+## Network aliases
+The dnsname plugin is capable of not only adding the container name for DNS resolution but also adding network aliases. These
+aliases are also added to the DNSMasq host file.
 
 ## Reporting issues
 If you are using dnsname code compiled directly from github, then reporting bugs and problem to the dnsname github issues tracker

--- a/README_PODMAN.md
+++ b/README_PODMAN.md
@@ -23,14 +23,7 @@ should already exist.
 ## Configure a CNI network for Podman
 
 1. Create a new network using `podman network create`.  For example, `podman network create foobar` will suffice.
-2. Using your favorite editor, edit `/etc/cni/net.d/foobar.conflist` and add the following with the plugins stanza:
-```
-      {
-     "type": "dnsname",
-         "domainName": "podman.io"
-      }
 
-```
 The following example [configuration file](example/cni-podman1.conflist) shows a usable example for Podman.
 
 ## Example: container name resolution

--- a/plugins/meta/dnsname/config.go
+++ b/plugins/meta/dnsname/config.go
@@ -41,7 +41,10 @@ var (
 // DNSNameConf represents the cni config with the domain name attribute
 type DNSNameConf struct {
 	types.NetConf
-	DomainName string `json:"domainName"`
+	DomainName    string   `json:"domainName"`
+	RuntimeConfig struct { // The capability arg
+		Aliases map[string][]string `json:"aliases"`
+	} `json:"runtimeConfig,omitempty"`
 }
 
 // dnsNameFile describes the plugin's attributes

--- a/plugins/meta/dnsname/files.go
+++ b/plugins/meta/dnsname/files.go
@@ -87,7 +87,7 @@ func generateDNSMasqConfig(config dnsNameFile) ([]byte, error) {
 }
 
 // appendToFile appends a new entry to the dnsmasqs hosts file
-func appendToFile(path, podname string, ips []*net.IPNet) error {
+func appendToFile(path, podname string, aliases []string, ips []*net.IPNet) error {
 	f, err := openFile(path)
 	if err != nil {
 		return err
@@ -98,7 +98,11 @@ func appendToFile(path, podname string, ips []*net.IPNet) error {
 		}
 	}()
 	for _, ip := range ips {
-		entry := fmt.Sprintf("%s\t%s\n", ip.IP.String(), podname)
+		entry := fmt.Sprintf("%s\t%s", ip.IP.String(), podname)
+		for _, alias := range aliases {
+			entry += fmt.Sprintf(" %s", alias)
+		}
+		entry += "\n"
 		if _, err = f.WriteString(entry); err != nil {
 			return err
 		}

--- a/plugins/meta/dnsname/main.go
+++ b/plugins/meta/dnsname/main.go
@@ -57,7 +57,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-
 	dnsNameConf, err := newDNSMasqFile(netConf.DomainName, result.Interfaces[0].Name, netConf.Name)
 	if err != nil {
 		return err
@@ -85,7 +84,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err := checkForDNSMasqConfFile(dnsNameConf); err != nil {
 		return err
 	}
-	if err := appendToFile(dnsNameConf.AddOnHostsFile, podname, ips); err != nil {
+	aliases := netConf.RuntimeConfig.Aliases[netConf.Name]
+	if err := appendToFile(dnsNameConf.AddOnHostsFile, podname, aliases, ips); err != nil {
 		return err
 	}
 	// Now we need to HUP
@@ -231,6 +231,7 @@ func parseConfig(stdin []byte, args string) (*DNSNameConf, *current.Result, stri
 	if err := json.Unmarshal(stdin, &conf); err != nil {
 		return nil, nil, "", errors.Wrap(err, "failed to parse network configuration")
 	}
+
 	// Parse previous result.
 	var result *current.Result
 	if conf.RawPrevResult != nil {


### PR DESCRIPTION
when podman passes us aliases, we need to make sure we pass this onto
the dnsmasq file so container name resolution will honor them.

Signed-off-by: baude <bbaude@redhat.com>