### PR TITLE
use tabs not spaces

### DIFF
--- a/plugins/meta/dnsname/files.go
+++ b/plugins/meta/dnsname/files.go
@@ -100,7 +100,7 @@ func appendToFile(path, podname string, aliases []string, ips []*net.IPNet) erro
 	for _, ip := range ips {
 		entry := fmt.Sprintf("%s\t%s", ip.IP.String(), podname)
 		for _, alias := range aliases {
-			entry += fmt.Sprintf(" %s", alias)
+			entry += fmt.Sprintf("\t%s", alias)
 		}
 		entry += "\n"
 		if _, err = f.WriteString(entry); err != nil {


### PR DESCRIPTION
dnsmasq requires the use of tabs

Signed-off-by: baude <bbaude@redhat.com>