### PR TITLE
Add missing comma in README_PODMAN.md

### DIFF
--- a/README_PODMAN.md
+++ b/README_PODMAN.md
@@ -38,7 +38,7 @@ lines to `/etc/cni/net.d/foobar.conflist` using your favorite editor. For exampl
       ...
       {
          "type": "dnsname",
-         "domainName": "dns.podman"
+         "domainName": "dns.podman",
          "capabilities": {
             "aliases": true
          }


### PR DESCRIPTION
There is a missing comma in the configuration snippet README_PODMAN.md that results in an invalid configuration.