### PR TITLE
fix typo in README_PODMAN

### DIFF
--- a/README_PODMAN.md
+++ b/README_PODMAN.md
@@ -57,7 +57,7 @@ respond with *podman rulez* on an http request.
 sudo podman run -dt --name web --network foobar quay.io/libpod/alpine_nginx:latest
 5139d65d22135e9ecab511559d863754550894a32285befd94dab231017048c2
 
-sudo podman run -it --name client --network foobar quay.io/libpod/alpine_nginx:latest curl http://web/
+sudo podman run -it --name client --network foobar quay.io/libpod/alpine_nginx:latest curl http://web.dns.podman/
 podman rulez
 ```
 


### PR DESCRIPTION
fix typo where ubuntu requires a fully qualified hostname

Fixes: #52

Signed-off-by: baude <bbaude@redhat.com>