### PR TITLE
Add dns search domain to cni result

### DIFF
--- a/plugins/meta/dnsname/dnsname_test.go
+++ b/plugins/meta/dnsname/dnsname_test.go
@@ -110,8 +110,11 @@ var _ = Describe("dnsname tests", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = current.GetResult(r)
+			result, err := current.GetResult(r)
 			Expect(err).NotTo(HaveOccurred())
+
+			// check that the dns search domain is set correctly
+			Expect(result.DNS.Search).To(Equal([]string{"foobar.io"}))
 
 			// Check that all configuration files are created
 			files, err := ioutil.ReadDir("/run/containers/cni/dnsname/test")

--- a/plugins/meta/dnsname/main.go
+++ b/plugins/meta/dnsname/main.go
@@ -99,6 +99,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// keep anything that was passed in already
 	nameservers = append(nameservers, result.DNS.Nameservers...)
 	result.DNS.Nameservers = nameservers
+	// add dns search domain
+	result.DNS.Search = append(result.DNS.Search, netConf.DomainName)
 	// Pass through the previous result
 	return types.PrintResult(result, netConf.CNIVersion)
 }


### PR DESCRIPTION
Local host name lookup is slow and can time out because
the search domain is not added to resolv.conf.

We have to add the configured domain name to the dns search domain
cni result so podman can read it back and add it to resolv.conf,
similar to how it is done for the nameservers.