### PR TITLE
return dnsmasq errors

### DIFF
--- a/plugins/meta/dnsname/service.go
+++ b/plugins/meta/dnsname/service.go
@@ -66,7 +66,10 @@ func (d dnsNameFile) start() error {
 		fmt.Sprintf("--conf-file=%s", d.ConfigFile),
 	}
 	cmd := exec.Command(d.Binary, args...)
-	return cmd.Run()
+	if b, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "dnsname error: dnsmasq failed with %q", b)
+	}
+	return nil
 }
 
 // stop stops the dnsmasq instance.


### PR DESCRIPTION
While debugging the rootless cni PR in podman I had a problem with the
dnsname plugin because dnsmasq failed to start. The returned error was
just `exit status 5`. This is not helpful. To solve this use CombinedOutput
and wrap the dnsmasq output to the returned error.

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>