### PR TITLE
Cleanup dangling config files

### DIFF
--- a/plugins/meta/dnsname/dnsname_test.go
+++ b/plugins/meta/dnsname/dnsname_test.go
@@ -197,8 +197,14 @@ var _ = Describe("dnsname tests", func() {
 
 			Expect(dnsDead).To(BeTrue())
 
-			// Cleanup behind ourselves
-			Expect(cleanup(d)).To(BeNil())
+			// defer cleanup is case it does not work automatically
+			defer func() {
+				_ = cleanup(d)
+			}()
+
+			// Check that the configuration directory is deleted
+			_, err = ioutil.ReadDir("/run/containers/cni/dnsname/test")
+			Expect(os.IsNotExist(err)).To(BeTrue())
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/plugins/meta/dnsname/main.go
+++ b/plugins/meta/dnsname/main.go
@@ -140,7 +140,12 @@ func cmdDel(args *skel.CmdArgs) error {
 	if !shouldHUP {
 		// if there are no hosts, we should just stop the dnsmasq instance to not take
 		// system resources
-		return dnsNameConf.stop()
+		err = dnsNameConf.stop()
+		if err != nil {
+			return err
+		}
+		// remove the config directory
+		return os.RemoveAll(domainBaseDir)
 	}
 	// Now we need to HUP
 	return dnsNameConf.hup()


### PR DESCRIPTION
When there are no longer containers attached to a network, dnsname
should remove the dangling config files for this network.

This fixes a bug where a recreated network could use an invalid dnsmasq
config because it used the old config for the new network.

Fixes containers/podman#10146
Fixes #54