### PR TITLE
Don't use LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo
 COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 
-LDFLAGS ?= -X main.gitCommit=$(GIT_COMMIT)
+LDFLAGS_DNSNAME ?= -X main.gitCommit=$(GIT_COMMIT)
 
 GO_BUILD=$(GO) build
 # Go module support: set `-mod=vendor` to use the vendored sources
@@ -39,7 +39,7 @@ gofmt:
 
 
 binaries:
-	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o bin/dnsname github.com/containers/dnsname/plugins/meta/dnsname
+	$(GO_BUILD) -ldflags '$(LDFLAGS_DNSNAME)' -o bin/dnsname github.com/containers/dnsname/plugins/meta/dnsname
 
 .PHONY: .gitvalidation
 .gitvalidation:


### PR DESCRIPTION
LDFLAGS is for the C linker. Using it for the Go linker breaks builds on
distributions, which use LDFLAGS to pass universal options to the C
linker. The Go linker does not understand these C linker flags.

See also https://github.com/containers/podman/commit/1df8a4b4677ef82069a582122ae1e86f6ab4ea3e

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>