### PR TITLE
Security fix for AppArmor instructions

### DIFF
--- a/README_PODMAN.md
+++ b/README_PODMAN.md
@@ -25,8 +25,7 @@ If your system uses AppArmor, it can prevent dnsmasq to open the necessary files
 Then reload the main dnsmasq profile:
 
 ```
-sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.dnsmasq
-sudo apparmor_parser /etc/apparmor.d/usr.sbin.dnsmasq
+sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.dnsmasq
 ```
 
 ## Build and install


### PR DESCRIPTION
`apparmor_parser -R $profile` unloads the dnsmasq profile - which also
means dnsmasq becomes unconfined (= without AppArmor restrictions).

`apparmor_parser $profile` loads the profile, but it can't apply it to the
already-running dnsmasq, so this instance stays unconfined.

Fix this security issue by using `apparmor_parser -r` (reload) which keeps
running processes confined.

Fixes: https://github.com/containers/dnsname/issues/82