### PR TITLE
only delete `dnsmasq.conf` in cleanup

### DIFF
--- a/plugins/meta/dnsname/dnsname_test.go
+++ b/plugins/meta/dnsname/dnsname_test.go
@@ -204,6 +204,8 @@ var _ = Describe("dnsname tests", func() {
 
 			// Check that the configuration directory is deleted
 			_, err = ioutil.ReadDir("/run/containers/cni/dnsname/test")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = ioutil.ReadFile("/run/containers/cni/dnsname/test/dnsmasq.conf")
 			Expect(os.IsNotExist(err)).To(BeTrue())
 			return nil
 		})

--- a/plugins/meta/dnsname/main.go
+++ b/plugins/meta/dnsname/main.go
@@ -152,8 +152,8 @@ func cmdDel(args *skel.CmdArgs) error {
 			logrus.Error(err)
 			return nil
 		}
-		// remove the config directory
-		err = os.RemoveAll(domainBaseDir)
+		// remove the config file
+		err = os.Remove(dnsNameConf.ConfigFile)
 		if err != nil {
 			logrus.Error(err)
 		}


### PR DESCRIPTION
This fixes a race condition with deleting the last network and adding a new one.

Previously the entire directory would be removed, and if this happened in between an `add` call's stat(configDir) and flock(configDir/lock) the stat() would see that the dir is there but then the flock() would error trying to open(configDir/lock).

Now it'll just delete the config file, which seems to be the original intent. The `addnhosts` file will already be empty so it seems harmless to just leave alone, and I'm guessing the `pidfile` is already handled appropriately by `dnsmasq`.